### PR TITLE
Change launch gallery layout from regular grid to masonry.

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -28,6 +28,7 @@ import { formatDateTime, formatLocalDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import { FavouritesContext } from "../contexts/favourites";
+import styles from "./launch.module.css";
 
 export default function Launch() {
 	let { launchId } = useParams();
@@ -259,12 +260,12 @@ function Video({ launch }) {
 
 function Gallery({ images }) {
 	return (
-		<SimpleGrid my="6" minChildWidth="350px" spacing="4">
+		<div className={styles.gallery}>
 			{images.map((image) => (
 				<a href={image} key={image}>
 					<Image src={image.replace("_o.jpg", "_z.jpg")} />
 				</a>
 			))}
-		</SimpleGrid>
+		</div>
 	);
 }

--- a/src/components/launch.module.css
+++ b/src/components/launch.module.css
@@ -1,0 +1,29 @@
+.gallery {
+	column-count: 1;
+	margin-top: 40px;
+}
+
+.gallery > a {
+	display: block;
+	margin-bottom: 20px;
+}
+
+.gallery > a img {
+	width: 100%;
+	height: auto;
+}
+
+@media (min-width: 768px) {
+	.gallery {
+		column-count: 2;
+		column-gap: 30px;
+		column-width: calc(50% - 30px);
+	}
+}
+
+@media (min-width: 1025px) {
+	.gallery {
+		column-count: 3;
+		column-width: calc(33.33% - 30px);
+	}
+}


### PR DESCRIPTION
In the regular grid layout for the launch image gallery, because some images are shorter than others, they leave spaces beneath them. To fix this, I changed the layout to the Masonry layout. Think Pinterest.